### PR TITLE
Support SHA-256 for certificate verification

### DIFF
--- a/receipt_validator.py
+++ b/receipt_validator.py
@@ -82,7 +82,7 @@ def lambda_handler(event, context):
             signer_info['signature'].native,
             receipt_data.native,
             padding.PKCS1v15(),
-            hashes.SHA1()
+            hashes.SHA256()
         )
     except Exception as e:
         error_message = str(e)


### PR DESCRIPTION
実際のAWSのラムダではこの部分はコメントになっているためこの変更は影響はしない

https://developer.apple.com/news/upcoming-requirements/?id=01242025a

<img width="1127" alt="apple-cert-verification-sha256" src="https://github.com/user-attachments/assets/34ac8fe0-a5a8-4745-a012-1224f60ed71b" />